### PR TITLE
fix(telegram): change dmPolicy from pairing to open

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,7 @@ cat > "$CONFIG" << JSONEOF
   "channels": {
     "telegram": {
       "enabled": true,
+      "dmPolicy": "open",
       "botToken": "$TELEGRAM_BOT_TOKEN"
     }
   },

--- a/openclaw.json.template
+++ b/openclaw.json.template
@@ -115,7 +115,7 @@
   "channels": {
     "telegram": {
       "enabled": true,
-      "dmPolicy": "pairing",
+      "dmPolicy": "open",
       "botToken": "<TELEGRAM_BOT_TOKEN>",
       "groupPolicy": "allowlist",
       "streamMode": "partial"


### PR DESCRIPTION
## Summary
- Changed `dmPolicy` from `"pairing"` to `"open"` in `openclaw.json.template` so the Telegram bot can freely receive and send DMs
- Added `"dmPolicy": "open"` to the runtime config generated by `entrypoint.sh` (was missing entirely)

## Root Cause
The `"pairing"` policy required users to pair with the bot before it could interact, which blocked Buzz v6.0 boot on Akash with the Telegram channel offline.

## Test plan
- [x] All 660 existing tests pass
- [ ] Deploy to Akash and verify Telegram bot receives/sends messages

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)