### PR TITLE
feat(discord): add Discord bot as Telegram backup

### DIFF
--- a/docs/plans/2026-02-25-discord-bot-design.md
+++ b/docs/plans/2026-02-25-discord-bot-design.md
@@ -1,0 +1,52 @@
+# Discord Bot Backup Channel — Design
+
+**Issue:** #2 — feat: add Discord bot to entrypoint as Telegram backup
+**Date:** 2026-02-25
+**Status:** Approved
+
+## Problem
+
+Buzz BD Agent communicates exclusively via Telegram. If Telegram is down or blocked, there is no backup channel. A Discord bot has already been registered (App ID: `1475792150380941372`) but is not wired into the system.
+
+## Solution
+
+Add Discord as a backup communication channel by adding a `discord` channel block to the OpenClaw config generated in `entrypoint.sh`. OpenClaw handles the Discord SDK internally, matching the existing Telegram pattern.
+
+## Changes
+
+### `entrypoint.sh`
+
+1. Add conditional Discord channel block to the generated `openclaw.json`:
+   - Only included when `DISCORD_BOT_TOKEN` env var is set
+   - Contains `botToken` and `appId` fields
+2. Add `DISCORD_BOT_TOKEN` to the ENV check log output
+
+### No other files changed
+
+- **Dockerfile**: No changes — OpenClaw handles Discord internally
+- **Python code**: No changes — out of scope (DiscordBridge can be added later)
+
+## Config Shape
+
+When `DISCORD_BOT_TOKEN` is set:
+
+```json
+"channels": {
+  "telegram": {
+    "enabled": true,
+    "dmPolicy": "open",
+    "botToken": "<TELEGRAM_BOT_TOKEN>"
+  },
+  "discord": {
+    "enabled": true,
+    "botToken": "<DISCORD_BOT_TOKEN>",
+    "appId": "1475792150380941372"
+  }
+}
+```
+
+When `DISCORD_BOT_TOKEN` is not set: config is unchanged (Telegram only).
+
+## Graceful Degradation
+
+Discord is a backup channel. Missing `DISCORD_BOT_TOKEN` produces a warning log but does not block startup. Telegram remains the primary channel.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,6 +53,12 @@ cat > "$CONFIG" << JSONEOF
   }
 }
 JSONEOF
+
+if [ -n "$DISCORD_BOT_TOKEN" ]; then
+  echo "[entrypoint] DISCORD_BOT_TOKEN found — adding Discord channel..."
+  jq '.channels.discord = {"enabled": true, "botToken": "'"$DISCORD_BOT_TOKEN"'", "appId": "1475792150380941372"}' "$CONFIG" > "${CONFIG}.tmp" && mv "${CONFIG}.tmp" "$CONFIG"
+fi
+
 echo "[entrypoint] Config generated at $CONFIG"
 
 echo "[entrypoint] Setting up ClawRouter..."
@@ -80,6 +86,7 @@ echo "[entrypoint] ENV check:"
 echo "  MINIMAX_API_KEY=$([ -n "$MINIMAX_API_KEY" ] && echo 'SET' || echo 'NOT SET')"
 echo "  BLOCKRUN_WALLET_KEY=$([ -n "$BLOCKRUN_WALLET_KEY" ] && echo 'SET' || echo 'NOT SET')"
 echo "  TELEGRAM_BOT_TOKEN=$([ -n "$TELEGRAM_BOT_TOKEN" ] && echo 'SET' || echo 'NOT SET')"
+echo "  DISCORD_BOT_TOKEN=$([ -n "$DISCORD_BOT_TOKEN" ] && echo 'SET' || echo 'NOT SET')"
 echo "  OpenRouter: REMOVED (using BlockRun via ClawRouter)"
 
 echo "[entrypoint] Starting gateway..."


### PR DESCRIPTION
## Summary
- Adds Discord channel to OpenClaw config in `entrypoint.sh` when `DISCORD_BOT_TOKEN` env var is set
- Uses `jq` to conditionally inject Discord channel block with App ID `1475792150380941372`
- Adds `DISCORD_BOT_TOKEN` to the ENV check log output
- Graceful degradation: Discord is skipped silently when token is absent; Telegram remains primary

## Changes
- **`entrypoint.sh`**: Conditional Discord channel injection via `jq` after base config generation + env var status logging
- **`docs/plans/2026-02-25-discord-bot-design.md`**: Design document for this feature

## Test plan
- [x] `bash -n entrypoint.sh` — syntax valid
- [x] Verified `jq` produces correct JSON with both Telegram and Discord channels when token is set
- [x] Verified Discord block is skipped when `DISCORD_BOT_TOKEN` is unset
- [x] Existing test suite passes (638/638)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)