### PR TITLE
feat(deploy): add BANKR_API_KEY and DISCORD_BOT_TOKEN env vars

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -23,6 +23,8 @@ services:
       - TELEGRAM_BOT_TOKEN=<SET_ON_DEPLOY>
       - MINIMAX_API_KEY=<SET_ON_DEPLOY>
       - BLOCKRUN_WALLET_KEY=<SET_ON_DEPLOY>
+      - BANKR_API_KEY=<SET_ON_DEPLOY>
+      - DISCORD_BOT_TOKEN=<SET_ON_DEPLOY>
     params:
       storage:
         data:


### PR DESCRIPTION
## Summary
- Adds `BANKR_API_KEY` and `DISCORD_BOT_TOKEN` environment variables to `deploy.yaml` (Akash SDL)
- Uses `<SET_ON_DEPLOY>` placeholder pattern — no hardcoded keys
- Follows the existing convention used by `TELEGRAM_BOT_TOKEN`, `MINIMAX_API_KEY`, and `BLOCKRUN_WALLET_KEY`

Closes #7

## Test plan
- [x] YAML syntax validated with `js-yaml`
- [x] No hardcoded secrets — both vars use `<SET_ON_DEPLOY>` placeholder
- [x] Follows existing env var pattern in the SDL

🤖 Generated with [Claude Code](https://claude.com/claude-code)